### PR TITLE
Fixed frequent "libpq too many clients" crash

### DIFF
--- a/backend/dbs/dbs.go
+++ b/backend/dbs/dbs.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log"
 	"reflect"
 	"sync"
 )
@@ -39,6 +40,12 @@ func ConnectPGDB(host string, user string, password string, dbname string) (*Saf
 }
 
 func (safeDB *SafeDB) Close() error {
+	safeDB.lock.Lock()
+	defer safeDB.lock.Unlock()
+	for query := range safeDB.stmts {
+		log.Printf("Closed query = %v\n", query)
+		safeDB.stmts[query].Close()
+	}
 	return safeDB.db.Close()
 }
 
@@ -67,9 +74,11 @@ func (safeDB *SafeDB) getStmt(query string) (*sql.Stmt, error) {
 		return stmt, nil
 	}
 	if stmt, err := safeDB.db.Prepare(query); err != nil {
+		stmt.Close()
 		return nil, err
 	} else {
 		safeDB.stmts[query] = stmt
+		log.Printf("Inserted query = %v\n", query)
 		return stmt, nil
 	}
 }

--- a/backend/dbs/dbs.go
+++ b/backend/dbs/dbs.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"log"
 	"reflect"
 	"sync"
 )
@@ -43,7 +42,6 @@ func (safeDB *SafeDB) Close() error {
 	safeDB.lock.Lock()
 	defer safeDB.lock.Unlock()
 	for query := range safeDB.stmts {
-		log.Printf("Closed query = %v\n", query)
 		safeDB.stmts[query].Close()
 	}
 	return safeDB.db.Close()
@@ -78,7 +76,6 @@ func (safeDB *SafeDB) getStmt(query string) (*sql.Stmt, error) {
 		return nil, err
 	} else {
 		safeDB.stmts[query] = stmt
-		log.Printf("Inserted query = %v\n", query)
 		return stmt, nil
 	}
 }

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -414,7 +414,7 @@ func CreateGetPostsHandler(safeDB *dbs.SafeDB) gin.HandlerFunc {
 			c.AbortWithStatus(http.StatusBadRequest)
 		}
 		posts := make([]Post, 0)
-		maxRows := 5
+		maxRows := 10
 		if newPosts, err := safeDB.Query(query, posts, maxRows, requestedUser, fromTimestamp); err != nil {
 			c.Error(errors.New(err, c, "CreateGetPostsHandler"))
 			return

--- a/webapp/src/PostPanel.js
+++ b/webapp/src/PostPanel.js
@@ -1,36 +1,47 @@
-import React, { useEffect, useState } from "react"
+import React, { useState } from "react"
 import PostSubmitForm from "./PostSubmitForm"
 import Posts from "./Posts"
 import { getPosts } from "./api-calls";
 
 export default function PostPanel({ username, onSelectUser }) {
   const [posts, setPosts] = useState([]);
+  const [loaded, setLoaded] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [bottomed, setBottomed] = useState(false);
 
-  useEffect(() => {
-    if (!loading) {
-      setLoading(true);
-      let fromTimestamp = "";
-      if (posts.length > 0) {
-        fromTimestamp = posts[posts.length - 1].postDate;
-      }
-      getPosts(username, true, fromTimestamp).then((result) => {
-        const [returnedPosts, _] = result;
-        setPosts(posts.concat(returnedPosts));
-      });
+  if (!bottomed && !loaded && !loading) {
+    setLoading(true);
+    let fromTimestamp = "";
+    if (posts.length > 0) {
+      fromTimestamp = posts[posts.length - 1].postDate;
     }
-  }, [loading]);
+    getPosts(username, true, fromTimestamp).then((result) => {
+      const [returnedPosts, ok] = result;
+      if (ok) {
+        if (returnedPosts.length > 0) {
+          setPosts(posts.concat(returnedPosts));
+        } else {
+          setBottomed(true);
+        }
+      }
+      setLoading(false);
+      setLoaded(true);
+    });
+  }
 
   function handleSubmit() {
     setPosts([]);
-    setLoading(false);
+    setBottomed(false);
+    setLoaded(false);
   }
 
-  window.onscroll = function(_e) {
-    if ((window.innerHeight * 1.2 + Math.round(window.scrollY)) >= document.body.offsetHeight) {
-      setLoading(false);
-    }
-  };
+  if (!bottomed) {
+    window.onscroll = function(_e) {
+      if ((window.innerHeight * 1.2 + Math.round(window.scrollY)) >= document.body.offsetHeight) {
+        setLoaded(false);
+      }
+    };
+  }
 
   return (
     <div id="post-panel" className="main-panel">

--- a/webapp/src/Posts.js
+++ b/webapp/src/Posts.js
@@ -3,7 +3,7 @@ import Post from './Post';
 
 export default function Posts({ posts, onSelectUser }) {
   const postsJSX = posts.map((post) => {
-    return <Post post={post} onSelectUser={onSelectUser} />
+    return <Post post={post} key={post.postDate} onSelectUser={onSelectUser} />
   });
   return (
     <div id="posts">

--- a/webapp/src/ProfilePanel.js
+++ b/webapp/src/ProfilePanel.js
@@ -21,12 +21,9 @@ export default function ProfilePanel({ username, selfUsername }) {
   const [numOfFollowers, setNumOfFollowers] = useState(0);
 
   if (loaded && username !== profileInfo.username) {
-    setLoaded(false);
-  }
-
-  if (loadedPosts && username !== profileInfo.username) {
     setPosts([]);
     setBottomed(false);
+    setLoaded(false);
     setLoadedPosts(false);
   }
 

--- a/webapp/src/ProfilePanel.js
+++ b/webapp/src/ProfilePanel.js
@@ -15,6 +15,7 @@ export default function ProfilePanel({ username, selfUsername }) {
   const [loaded, setLoaded] = useState(false);
   const [loadingPosts, setLoadingPosts] = useState(false);
   const [loadedPosts, setLoadedPosts] = useState(false);
+  const [bottomed, setBottomed] = useState(false);
   const [posts, setPosts] = useState([]);
   const [numOfFollowings, setNumOfFollowings] = useState(0);
   const [numOfFollowers, setNumOfFollowers] = useState(0);
@@ -25,6 +26,7 @@ export default function ProfilePanel({ username, selfUsername }) {
 
   if (loadedPosts && username !== profileInfo.username) {
     setPosts([]);
+    setBottomed(false);
     setLoadedPosts(false);
   }
 
@@ -58,25 +60,33 @@ export default function ProfilePanel({ username, selfUsername }) {
     );
   }
 
-  if (!loadedPosts && !loadingPosts) {
+  if (!bottomed && !loadedPosts && !loadingPosts) {
     setLoadingPosts(true);
     let fromTimestamp = "";
     if (posts.length > 0) {
       fromTimestamp = posts[posts.length - 1].postDate;
     }
     getPosts(username, false, fromTimestamp).then((result) => {
-      const [returnedPosts, _] = result;
-      setPosts(posts.concat(returnedPosts));
+      const [returnedPosts, ok] = result;
+      if (ok) {
+        if (returnedPosts.length > 0) {
+          setPosts(posts.concat(returnedPosts));
+        } else {
+          setBottomed(true);
+        }
+      }
       setLoadingPosts(false);
       setLoadedPosts(true);
     });
   }
 
-  window.onscroll = function(_e) {
-    if ((window.innerHeight * 1.2 + Math.round(window.scrollY)) >= document.body.offsetHeight) {
-      setLoadedPosts(false);
-    }
-  };
+  if (!bottomed) {
+    window.onscroll = function(_e) {
+      if ((window.innerHeight * 1.2 + Math.round(window.scrollY)) >= document.body.offsetHeight) {
+        setLoadedPosts(false);
+      }
+    };
+  }
 
   function handleClick() {
     if (followState === "no") {


### PR DESCRIPTION
Fixed frequent "libpq too many clients" crash by introducing `bottomed` state to PostPanel and HomePanel component. The reason for this crash is two fold:

- Request for new posts are sent after user scrolled down to 80-100% of the view.
- If there are no more earlier posts, the view does not lengthen and the front-end keep requesting each time a scroll event fires between that 80-100% height of the view.

This leads to a swath of requests that overwhelms the Database, since any tiny movement is registered. The solution is to keep a `bottomed` state that is set when we know we don't have any earlier posts. If this `bottomed` state is set, the scroll event listener is removed.